### PR TITLE
[Feature/admin-page] 메인(로그인), 관리자 페이지 나눔

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cozyformom_admin",
       "version": "0.1.0",
       "dependencies": {
+        "@types/react": "^19.0.8",
         "axios": "^1.7.9",
         "cra-template": "1.2.0",
         "react": "^19.0.0",
@@ -3459,6 +3460,24 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
+    "node_modules/@types/react": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
+      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
+      "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5790,6 +5809,12 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "cozyformom_admin",
       "version": "0.1.0",
       "dependencies": {
+        "@types/axios": "^0.9.36",
+        "axios": "^1.7.9",
         "cra-template": "1.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3222,6 +3224,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@types/axios": {
+      "version": "0.9.36",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
+      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4431,6 +4439,31 @@
       "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -12433,6 +12466,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "cozyformom_admin",
       "version": "0.1.0",
       "dependencies": {
-        "@types/axios": "^0.9.36",
         "axios": "^1.7.9",
         "cra-template": "1.2.0",
         "react": "^19.0.0",
@@ -3223,12 +3222,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/@types/axios": {
-      "version": "0.9.36",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
-      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@types/axios": "^0.9.36",
     "axios": "^1.7.9",
     "cra-template": "1.2.0",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/axios": "^0.9.36",
+    "axios": "^1.7.9",
     "cra-template": "1.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/react": "^19.0.8",
     "axios": "^1.7.9",
     "cra-template": "1.2.0",
     "react": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,32 @@
 /* src/App.tsx */
 
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import CozyLogViolationList from './pages/CozyLogViolationList/CozyLogViolationList.tsx';
-import CommentViolationList from './pages/CommentViolationList/CommentViolationList.tsx';
+import './App.css'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import LoginPage from './pages/Login/Login.tsx';
+import AdminPage from './pages/Admin/Admin.tsx';
+import PrivateRoute from './PrivateRoute.tsx';
 
 function App() {
   return (
     <Router>
-      <div>
-        <nav style={{ display: 'flex', 
-          justifyContent: 'center', /* 가운데 정렬 */
-          alignItems: 'center',
-          gap: '2rem',
-          marginTop: '2rem' }}>
-          <Link to="/cozylog-violations">코지로그 신고 목록</Link>
-          <Link to="/comment-violations">댓글 신고 목록</Link>
-        </nav>
+      <Routes>
+        {/* <Route path="/" element={<LoginPage />} /> */}
+        <Route path="/" element={<LoginPage />} />
 
-        <Routes>
-          <Route path="/cozylog-violations" element={<CozyLogViolationList />} />
-          <Route path="/comment-violations" element={<CommentViolationList />} />
-          {/* 기본 라우트 등 추가 */}
-        </Routes>
-      </div>
+        {/* "/admin/*" → PrivateRoute(로그인 필요) */}
+        <Route 
+          path="/admin/*" 
+          element={
+            <PrivateRoute>
+              <AdminPage />
+            </PrivateRoute>
+          } 
+        />
+
+        {/* 기타 */}
+        {/* <Route path="*" element={<NotFoundPage />} /> */}
+      </Routes>
     </Router>
   );
 }

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,0 +1,24 @@
+// src/PrivateRoute.tsx
+
+import React, { JSX } from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children: JSX.Element;
+}
+
+const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
+  // 실제로는 JWT 토큰 검사, 서버 검증, Redux 상태, etc.
+  // 아래 예시는 단순히 로컬 스토리지 토큰 존재 여부로 가정
+  const isLoggedIn = !!localStorage.getItem('accessToken');
+
+  if (!isLoggedIn) {
+    // 로그인이 안 되어 있다면, 로그인 페이지로 리다이렉트
+    return <Navigate to="/login" replace />;
+  }
+
+  // 로그인이 되어 있으면, 보호된 페이지(자식 컴포넌트)를 그대로 렌더링
+  return children;
+};
+
+export default PrivateRoute;

--- a/src/api/baseApi.ts
+++ b/src/api/baseApi.ts
@@ -1,0 +1,97 @@
+import axios, { AxiosResponse } from 'axios';
+
+// 1. Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: 'https://api.cozyformom.com/api/v1', // 서버 API 기본 주소
+  withCredentials: true,              // 필요에 따라 쿠키 인증 등
+  // timeout: 5000,                   // 타임아웃 설정 등
+});
+
+// 2. 요청/응답 인터셉터 설정(선택)
+apiClient.interceptors.request.use(
+    (config) => {
+      // 요청 전 헤더에 토큰을 붙이거나 등등
+      // config.headers.Authorization = `Bearer ${token}`;
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
+    }
+  );
+  
+  apiClient.interceptors.response.use(
+    (response) => {
+      // 필요 시 응답을 가공해서 리턴
+      return response;
+    },
+    (error) => {
+      // 에러 로깅, 토큰 만료 체크 등
+      return Promise.reject(error);
+    }
+  );
+
+// 3. API 함수 정의 (GET/POST/PUT/DELETE 등)
+/* 신고된 코지로그 리스트 조회(GET) */
+export const getViolatedCozylogs = async (userId: string) => {
+    const response: AxiosResponse<{ 
+      id: string; 
+      name: string; 
+      email: string; 
+    }> = await apiClient.get(`/admin/violation/log?page=0&size=10`);  // TODO: 사이즈 안주면 디폴트가 10인지 물어보기
+    return response.data;
+  };
+  
+  /* 신고된 댓글 리스트 조회(GET) */
+export const getViolatedComments = async (userId: string) => {
+    const response: AxiosResponse<{ 
+      id: string; 
+      name: string; 
+      email: string; 
+    }> = await apiClient.get(`/v1/admin/violation/comment?page=&size=10`);
+    return response.data;
+  };
+
+  /* 코지로그 신고 처리 (POST) */
+  interface CreatePostData {
+    reportId: number;
+    process: string;  // 1. 승인할 떄 → APPROVED  2. 반려할 때 → REJECTED
+  }
+  
+  interface CreatedPostResponse {
+    id: number;
+    title: string;
+    content: string;
+    createdAt: string;
+  }
+  
+  export const blockCozylog = async (postData: CreatePostData) => {
+    const response: AxiosResponse<CreatedPostResponse> = await apiClient.post(
+      '/admin/violation/log',
+      postData
+    );
+    return response.data;
+  };
+
+  /* 댓글 신고 처리 (POST) */
+  interface CreatePostData {
+    reportedId: number;
+    content: string;  // 1. 승인할 떄 → APPROVED  2. 반려할 때 → REJECTED
+  }
+  
+  interface CreatedPostResponse {
+    id: number;
+    title: string;
+    content: string;
+    createdAt: string;
+  }
+  
+  export const blockComment = async (postData: CreatePostData) => {
+    const response: AxiosResponse<CreatedPostResponse> = await apiClient.post(
+      '/cozy-log/violation/comment',
+      postData
+    );
+    return response.data;
+  };
+  
+  /** 예시: 공통적으로 쓸 수도 있는 'apiClient' 자체를 export */
+  export default apiClient;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import './index.css';
 import App from './App.tsx';
 import reportWebVitals from './reportWebVitals.ts';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
     <App />

--- a/src/pages/Admin/Admin.css
+++ b/src/pages/Admin/Admin.css
@@ -1,0 +1,5 @@
+/* src/Admin.css */
+
+.admin-container {
+    text-align: center;
+  }

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -1,0 +1,32 @@
+// pages/AdminPage.tsx
+
+import React from 'react';
+import './Admin.css'
+import { Routes, Route, Link } from 'react-router-dom';
+import CozyLogViolationList from '../CozyLogViolationList/CozyLogViolationList.tsx';
+import CommentViolationList from '../CommentViolationList/CommentViolationList.tsx';
+
+function AdminPage() {
+  return (
+    <div className="admin-container">
+      <h2>관리자 페이지</h2>
+      <nav style={{ display: 'flex', 
+                justifyContent: 'center', /* 가운데 정렬 */
+                alignItems: 'center',
+                gap: '2rem',
+                marginTop: '2rem' }}>
+                <Link to="/cozylog-violations">코지로그 신고 목록</Link>
+                <Link to="/comment-violations">댓글 신고 목록</Link>
+              </nav>
+
+      {/* 서브 라우팅 */}
+      <Routes>
+        <Route path="cozylog-violations" element={<CozyLogViolationList />} />
+        <Route path="comment-violations" element={<CommentViolationList />} />
+        {/* <Route path="*" element={<NotFoundInAdmin />} /> */}
+      </Routes>
+    </div>
+  );
+}
+
+export default AdminPage;

--- a/src/pages/Login/Login.css
+++ b/src/pages/Login/Login.css
@@ -1,1 +1,7 @@
 /* src/pages/Login/Login.css */
+
+.login-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,1 +1,12 @@
 /* src/pages/Login/Login.tsx */
+
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+
+function LoginPage() {
+    return (
+        <div className='login-container'></div>
+    );
+}
+
+export default LoginPage;


### PR DESCRIPTION
- Login.tsx, Login.css 틀 생성 (로그인 페이지)
- Admin.tsx, Admin.css 생성 (관리자 페이지 - 코지로그/댓글 신고 목록 조회 컴포넌트 포함)
- React Router 6+에서 흔히 쓰는 ‘Protected Route(Private Route)’ 패턴 적용
  (로그인 인증 성공 시에만 관리자 페이지로 넘어갈 수 있도록 구현)